### PR TITLE
Add support for creating a FileReader from bytes

### DIFF
--- a/src/file_reader/record.rs
+++ b/src/file_reader/record.rs
@@ -6,6 +6,7 @@ use crate::file_reader::FileReader;
 use crate::utility;
 use std::error::Error;
 use std::fmt;
+use std::io::{Read, Seek};
 
 /// How in depth (strict) do you want this query to be? Higher values
 /// may provide a higher false-positive rate. We recommend starting at "0", the lowest strictness setting,
@@ -127,7 +128,10 @@ Public Access Point: {:#?}",
 
 impl Record {
     /// Parses the raw bytes at the leaf of the tree into a usable Record struct
-    pub(crate) fn parse(raw: Vec<u8>, file: &mut FileReader) -> Result<Record, Box<dyn Error>> {
+    pub(crate) fn parse<R: Read + Seek>(
+        raw: Vec<u8>,
+        file: &mut FileReader<R>,
+    ) -> Result<Record, Box<dyn Error>> {
         let mut current_byte = 0;
         let mut record = Record::default();
         // files with the binary data flag set have two additional bytes per record

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -24,6 +24,18 @@ fn ipv6() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn ipv6_from_memory() -> Result<(), Box<dyn Error>> {
+    let mut path_buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path_buf.push("resources/IPQualityScore-IP-Reputation-Database-IPv6.ipqs");
+    let bytes = std::fs::read(path_buf)?;
+    let mut reader = FileReader::from_bytes(bytes)?;
+    let ip: IpAddr = IpAddr::V6(Ipv6Addr::from_str(IPV6_EXAMPLE)?);
+    let _ = reader.fetch(&ip)?;
+
+    Ok(())
+}
+
+#[test]
 fn specific_details() {
     let mut path_buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path_buf.push("resources/IPQualityScore-IP-Reputation-Database-IPv4.ipqs");


### PR DESCRIPTION
In scenarios with high concurrency or in the presence of slow I/O, it could be useful to pre-load all the data into memory and operate on that.

Future work:
* Maybe rename `FileReader` (since this is already an API breaking change, it might be useful)
* Maybe create `InMemoryReader` and extract common parts to avoid changing the signature of `FileReader`
* For a separate `InMemoryReader`, make it not require mutable access for lookups (so it can be freely shared among threads)